### PR TITLE
HEAD and redirect responses

### DIFF
--- a/http/request.rkt
+++ b/http/request.rkt
@@ -603,7 +603,8 @@
   (define location (redirect-uri h))
   (cond
    [(and location (> redirects 0))
-    (read-entity/bytes in h) ;consume/ignore
+    (unless (equal? method "HEAD") ; there's never a body for a HEAD request
+      (read-entity/bytes in h)) ;consume/ignore
     (define old-url (string->url uri))
     (define new-url (combine-url/relative old-url location))
     ;; Can we use the existing connection for the new location?


### PR DESCRIPTION
The second patch addresses the main problem: if a HEAD request gets a redirection response, redirection handling tried to read a body that isn't there.

The first patch is more complex. It addresses the use of `make-input-port` and blocking operations in the read function, which should never block. I think the only real effect of the bug is to disable Ctl-C if communication stalls, though.
